### PR TITLE
Delete conda_build_config.yaml as no more assimp 5.2.4 workaround is necessary

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,4 +1,0 @@
-# Workaround for https://github.com/conda-forge/staged-recipes/pull/20672#issuecomment-1274683552,
-# to be remove once https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/3439 is merged
-assimp:  # [win]
-  - 5.2.4  # [win]


### PR DESCRIPTION
Superseded by https://github.com/conda-forge/gz-physics-feedstock/pull/1 . No bump of build number is necessary as this is just a cleanup.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
