### PR TITLE
Backport relocatability fixes

### DIFF
--- a/recipe/507.patch
+++ b/recipe/507.patch
@@ -1,0 +1,454 @@
+From 63dcd145e5bf3e46e8051b96896208b8e6057241 Mon Sep 17 00:00:00 2001
+From: Silvio Traversaro <silvio.traversaro@iit.it>
+Date: Fri, 21 Apr 2023 18:04:29 +0200
+Subject: [PATCH 1/3] Add optional binary relocatability
+
+Signed-off-by: Silvio Traversaro <silvio.traversaro@iit.it>
+---
+ CMakeLists.txt                                |  9 ++--
+ dartsim/CMakeLists.txt                        |  4 +-
+ include/gz/physics/InstallationDirectories.hh | 43 +++++++++++++++++++
+ include/gz/physics/config.hh.in               |  2 +-
+ src/CMakeLists.txt                            | 13 +++++-
+ src/InstallationDirectories.cc                | 36 ++++++++++++++++
+ test/integration/CMakeLists.txt               |  4 +-
+ test/performance/CMakeLists.txt               |  2 +
+ test/regression/CMakeLists.txt                |  4 +-
+ tpe/lib/CMakeLists.txt                        |  4 +-
+ tpe/plugin/CMakeLists.txt                     |  4 +-
+ 11 files changed, 115 insertions(+), 10 deletions(-)
+ create mode 100644 include/gz/physics/InstallationDirectories.hh
+ create mode 100644 src/InstallationDirectories.cc
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index f7feeffde..da1b2b19c 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -37,9 +37,9 @@ message(STATUS "\n\n-- ====== Finding Dependencies ======")
+ 
+ #--------------------------------------
+ # Find gz-common
+-gz_find_package(gz-common5
++gz_find_package(gz-common5 REQUIRED
+   COMPONENTS geospatial graphics profiler
+-  REQUIRED_BY heightmap mesh dartsim tpe tpelib bullet)
++  )
+ set(GZ_COMMON_VER ${gz-common5_VERSION_MAJOR})
+ 
+ #--------------------------------------
+@@ -93,8 +93,11 @@ message(STATUS "-------------------------------------------\n")
+ set(GZ_PHYSICS_RESOURCE_DIR "${CMAKE_SOURCE_DIR}/resources")
+ 
+ # Plugin install dirs
++set(GZ_PHYSICS_ENGINE_RELATIVE_INSTALL_DIR
++  ${GZ_LIB_INSTALL_DIR}/gz-${GZ_DESIGNATION}-${PROJECT_VERSION_MAJOR}/engine-plugins
++)
+ set(GZ_PHYSICS_ENGINE_INSTALL_DIR
+-  ${CMAKE_INSTALL_PREFIX}/${GZ_LIB_INSTALL_DIR}/gz-${GZ_DESIGNATION}-${PROJECT_VERSION_MAJOR}/engine-plugins
++  ${CMAKE_INSTALL_PREFIX}/${GZ_PHYSICS_ENGINE_RELATIVE_INSTALL_DIR}
+ )
+ 
+ #============================================================================
+diff --git a/dartsim/CMakeLists.txt b/dartsim/CMakeLists.txt
+index 2b328b09d..35b416bb3 100644
+--- a/dartsim/CMakeLists.txt
++++ b/dartsim/CMakeLists.txt
+@@ -90,7 +90,9 @@ gz_build_tests(
+     ${PROJECT_LIBRARY_TARGET_NAME}-sdf
+     ${PROJECT_LIBRARY_TARGET_NAME}-heightmap
+     ${PROJECT_LIBRARY_TARGET_NAME}-mesh
+-  TEST_LIST tests)
++  TEST_LIST tests
++  ENVIRONMENT
++    GZ_PHYSICS_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX})
+ 
+ foreach(test ${tests})
+ 
+diff --git a/include/gz/physics/InstallationDirectories.hh b/include/gz/physics/InstallationDirectories.hh
+new file mode 100644
+index 000000000..a8b975ce9
+--- /dev/null
++++ b/include/gz/physics/InstallationDirectories.hh
+@@ -0,0 +1,43 @@
++/*
++ * Copyright (C) 2023 Open Source Robotics Foundation
++ *
++ * Licensed under the Apache License, Version 2.0 (the "License");
++ * you may not use this file except in compliance with the License.
++ * You may obtain a copy of the License at
++ *
++ *     http://www.apache.org/licenses/LICENSE-2.0
++ *
++ * Unless required by applicable law or agreed to in writing, software
++ * distributed under the License is distributed on an "AS IS" BASIS,
++ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++ * See the License for the specific language governing permissions and
++ * limitations under the License.
++ *
++ */
++
++#ifndef GZ_PHYSICS_INSTALLATION_DIRECTORIES_HH_
++#define GZ_PHYSICS_INSTALLATION_DIRECTORIES_HH_
++
++#include <string>
++
++#include <gz/physics/config.hh>
++#include <gz/physics/Export.hh>
++
++namespace gz
++{
++  namespace physics
++  {
++    inline namespace GZ_PHYSICS_VERSION_NAMESPACE {
++
++    /// \brief getInstallPrefix return the install prefix of the library
++    /// i.e. CMAKE_INSTALL_PREFIX unless the library has been moved
++    GZ_PHYSICS_VISIBLE std::string getInstallPrefix();
++
++    /// \brief getEngineInstallDir return the install directory of the engines
++    GZ_PHYSICS_VISIBLE std::string getEngineInstallDir();
++
++    }
++  }
++}
++
++#endif
+diff --git a/include/gz/physics/config.hh.in b/include/gz/physics/config.hh.in
+index 75e9338e2..d0c68462d 100644
+--- a/include/gz/physics/config.hh.in
++++ b/include/gz/physics/config.hh.in
+@@ -28,7 +28,7 @@
+ #define GZ_PHYSICS_VERSION "${PROJECT_VERSION}"
+ #define GZ_PHYSICS_VERSION_FULL "${PROJECT_VERSION_FULL}"
+ 
+-#define GZ_PHYSICS_ENGINE_INSTALL_DIR "${GZ_PHYSICS_ENGINE_INSTALL_DIR}"
++#define GZ_PHYSICS_ENGINE_INSTALL_DIR _Pragma ("GCC warning \"'GZ_PHYSICS_ENGINE_INSTALL_DIR' macro is deprecated, use gz::physics::getEngineInstallDir() function instead. \"") "${GZ_PHYSICS_ENGINE_INSTALL_DIR}"
+ 
+ #define GZ_PHYSICS_VERSION_HEADER "Gazebo Physics, version ${PROJECT_VERSION_FULL}\nCopyright (C) 2017 Open Source Robotics Foundation.\nReleased under the Apache 2.0 License.\n\n"
+ 
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 14f4f830f..9b11c4103 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -1,9 +1,18 @@
+ gz_get_libsources_and_unittests(sources gtest_sources)
+ gz_create_core_library(SOURCES ${sources} CXX_STANDARD 17)
++gz_add_get_install_prefix_impl(GET_INSTALL_PREFIX_FUNCTION gz::physics::getInstallPrefix
++                               GET_INSTALL_PREFIX_HEADER gz/physics/InstallationDirectories.hh
++                               OVERRIDE_INSTALL_PREFIX_ENV_VARIABLE GZ_PHYSICS_INSTALL_PREFIX)
+ 
++set_property(
++  SOURCE InstallationDirectories.cc
++  PROPERTY COMPILE_DEFINITIONS
++  GZ_PHYSICS_ENGINE_RELATIVE_INSTALL_DIR="${GZ_PHYSICS_ENGINE_RELATIVE_INSTALL_DIR}"
++)
+ 
+ target_link_libraries(${PROJECT_LIBRARY_TARGET_NAME}
+   PUBLIC
++    gz-common${GZ_COMMON_VER}::gz-common${GZ_COMMON_VER}
+     gz-math${GZ_MATH_VER}::gz-math${GZ_MATH_VER}
+     gz-utils${GZ_UTILS_VER}::gz-utils${GZ_UTILS_VER}
+     gz-plugin${GZ_PLUGIN_VER}::register
+@@ -11,7 +20,9 @@ target_link_libraries(${PROJECT_LIBRARY_TARGET_NAME}
+ 
+ gz_build_tests(
+   TYPE UNIT
+-  SOURCES ${gtest_sources})
++  SOURCES ${gtest_sources}
++  ENVIRONMENT
++    GZ_PHYSICS_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX})
+ 
+ if(TARGET UNIT_FindFeatures_TEST)
+   target_link_libraries(UNIT_FindFeatures_TEST
+diff --git a/src/InstallationDirectories.cc b/src/InstallationDirectories.cc
+new file mode 100644
+index 000000000..5f51c076a
+--- /dev/null
++++ b/src/InstallationDirectories.cc
+@@ -0,0 +1,36 @@
++/*
++ * Copyright (C) 2023 Open Source Robotics Foundation
++ *
++ * Licensed under the Apache License, Version 2.0 (the "License");
++ * you may not use this file except in compliance with the License.
++ * You may obtain a copy of the License at
++ *
++ *     http://www.apache.org/licenses/LICENSE-2.0
++ *
++ * Unless required by applicable law or agreed to in writing, software
++ * distributed under the License is distributed on an "AS IS" BASIS,
++ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++ * See the License for the specific language governing permissions and
++ * limitations under the License.
++ *
++*/
++
++#include <gz/physics/config.hh>
++#include <gz/physics/InstallationDirectories.hh>
++
++#include <gz/common/Filesystem.hh>
++
++namespace gz
++{
++namespace physics
++{
++inline namespace GZ_PHYSICS_VERSION_NAMESPACE {
++
++std::string getEngineInstallDir()
++{
++  return gz::common::joinPaths(getInstallPrefix(), GZ_PHYSICS_ENGINE_RELATIVE_INSTALL_DIR);
++}
++
++}
++}
++}
+diff --git a/test/integration/CMakeLists.txt b/test/integration/CMakeLists.txt
+index a7c565c75..6cf8c9eb6 100644
+--- a/test/integration/CMakeLists.txt
++++ b/test/integration/CMakeLists.txt
+@@ -14,7 +14,9 @@ gz_build_tests(
+     gz-plugin${GZ_PLUGIN_VER}::loader
+   INCLUDE_DIRS
+     ${PROJECT_SOURCE_DIR}/src
+-  TEST_LIST list)
++  TEST_LIST list
++  ENVIRONMENT
++    GZ_PHYSICS_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX})
+ 
+ if (BUILD_TESTING)
+   foreach(test ${list})
+diff --git a/test/performance/CMakeLists.txt b/test/performance/CMakeLists.txt
+index 1034620fa..6a1627d67 100644
+--- a/test/performance/CMakeLists.txt
++++ b/test/performance/CMakeLists.txt
+@@ -12,4 +12,6 @@ gz_build_tests(
+   SOURCES ${tests}
+   INCLUDE_DIRS     
+     ${PROJECT_SOURCE_DIR}/src
++  ENVIRONMENT
++    GZ_PHYSICS_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
+ )
+diff --git a/test/regression/CMakeLists.txt b/test/regression/CMakeLists.txt
+index f56c54cd5..b7f08a009 100644
+--- a/test/regression/CMakeLists.txt
++++ b/test/regression/CMakeLists.txt
+@@ -2,4 +2,6 @@ gz_get_sources(tests)
+ 
+ gz_build_tests(
+   TYPE REGRESSION
+-  SOURCES ${tests})
++  SOURCES ${tests}
++  ENVIRONMENT
++    GZ_PHYSICS_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX})
+diff --git a/tpe/lib/CMakeLists.txt b/tpe/lib/CMakeLists.txt
+index ef5979fbd..7b18a37f2 100644
+--- a/tpe/lib/CMakeLists.txt
++++ b/tpe/lib/CMakeLists.txt
+@@ -25,4 +25,6 @@ gz_build_tests(
+     ${PROJECT_LIBRARY_TARGET_NAME}-sdf
+     ${PROJECT_LIBRARY_TARGET_NAME}-mesh
+     ${tpelib_target}
+-  TEST_LIST tests)
++  TEST_LIST tests
++  ENVIRONMENT
++    GZ_PHYSICS_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX})
+diff --git a/tpe/plugin/CMakeLists.txt b/tpe/plugin/CMakeLists.txt
+index f3075af5b..3d73d6828 100644
+--- a/tpe/plugin/CMakeLists.txt
++++ b/tpe/plugin/CMakeLists.txt
+@@ -59,7 +59,9 @@ gz_build_tests(
+     gz-common${GZ_COMMON_VER}::gz-common${GZ_COMMON_VER}
+     ${PROJECT_LIBRARY_TARGET_NAME}-sdf
+     ${PROJECT_LIBRARY_TARGET_NAME}-mesh
+-  TEST_LIST tests)
++  TEST_LIST tests
++  ENVIRONMENT
++    GZ_PHYSICS_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX})
+ 
+ foreach(test ${tests})
+ 
+
+From 2355925437a0df4552090712bddf1d6c9d84a243 Mon Sep 17 00:00:00 2001
+From: Silvio Traversaro <silvio.traversaro@iit.it>
+Date: Mon, 8 May 2023 13:10:05 +0200
+Subject: [PATCH 2/3] Address reviews
+
+Signed-off-by: Silvio Traversaro <silvio.traversaro@iit.it>
+---
+ CMakeLists.txt                 |   4 +-
+ src/CMakeLists.txt             |   1 -
+ src/InstallationDirectories.cc | 121 ++++++++++++++++++++++++++++++++-
+ 3 files changed, 120 insertions(+), 6 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index da1b2b19c..edde87869 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -37,9 +37,9 @@ message(STATUS "\n\n-- ====== Finding Dependencies ======")
+ 
+ #--------------------------------------
+ # Find gz-common
+-gz_find_package(gz-common5 REQUIRED
++gz_find_package(gz-common5
+   COMPONENTS geospatial graphics profiler
+-  )
++  REQUIRED_BY heightmap mesh dartsim tpe tpelib bullet)
+ set(GZ_COMMON_VER ${gz-common5_VERSION_MAJOR})
+ 
+ #--------------------------------------
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 9b11c4103..e3a178297 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -12,7 +12,6 @@ set_property(
+ 
+ target_link_libraries(${PROJECT_LIBRARY_TARGET_NAME}
+   PUBLIC
+-    gz-common${GZ_COMMON_VER}::gz-common${GZ_COMMON_VER}
+     gz-math${GZ_MATH_VER}::gz-math${GZ_MATH_VER}
+     gz-utils${GZ_UTILS_VER}::gz-utils${GZ_UTILS_VER}
+     gz-plugin${GZ_PLUGIN_VER}::register
+diff --git a/src/InstallationDirectories.cc b/src/InstallationDirectories.cc
+index 5f51c076a..fef091a26 100644
+--- a/src/InstallationDirectories.cc
++++ b/src/InstallationDirectories.cc
+@@ -15,20 +15,135 @@
+  *
+ */
+ 
++#include <regex>
++
+ #include <gz/physics/config.hh>
+ #include <gz/physics/InstallationDirectories.hh>
+ 
+-#include <gz/common/Filesystem.hh>
+-
+ namespace gz
+ {
+ namespace physics
+ {
+ inline namespace GZ_PHYSICS_VERSION_NAMESPACE {
+ 
++// We locally import the gz::common::joinPaths function
++// See https://github.com/gazebosim/gz-physics/pull/507#discussion_r1186919267
++// for more details
++
++// Function imported from
++// https://github.com/gazebosim/gz-common/blob/ignition-common4_4.6.2/src/FilesystemBoost.cc#L507
++#ifndef WIN32
++static const char preferred_separator = '/';
++#else  // Windows
++static const char preferred_separator = '\\';
++#endif
++const std::string separator(const std::string &_p)
++{
++  return _p + preferred_separator;
++}
++
++// Function imported from
++// https://github.com/gazebosim/gz-common/blob/ignition-common4_4.6.2/src/Filesystem.cc#L227
++std::string checkWindowsPath(const std::string _path)
++{
++  if (_path.empty())
++    return _path;
++
++  // Check if this is a http or https, if so change backslashes generated by
++  // jointPaths to '/'
++  if ((_path.size() > 7 && 0 == _path.compare(0, 7, "http://")) ||
++      (_path.size() > 8 && 0 == _path.compare(0, 8, "https://")))
++  {
++    return std::regex_replace(_path, std::regex(R"(\\)"), "/");
++  }
++
++  // This is a Windows path, convert all '/' into backslashes
++  std::string result = std::regex_replace(_path, std::regex(R"(/)"), "\\");
++  std::string drive_letters;
++
++  // only Windows contains absolute paths starting with drive letters
++  if (result.length() > 3 && 0 == result.compare(1, 2, ":\\"))
++  {
++    drive_letters = result.substr(0, 3);
++    result = result.substr(3);
++  }
++  result = drive_letters + std::regex_replace(
++    result, std::regex("[<>:\"|?*]"), "");
++  return result;
++}
++
++// Function imported from
++// https://github.com/gazebosim/gz-common/blob/ignition-common4_4.6.2/src/Filesystem.cc#L256
++std::string joinPaths(const std::string &_path1,
++                      const std::string &_path2)
++{
++
++  /// This function is used to avoid duplicated path separators at the
++  /// beginning/end of the string, and between the two paths being joined.
++  /// \param[in] _path This is the string to sanitize.
++  /// \param[in] _stripLeading True if the leading separator should be
++  /// removed.
++  auto sanitizeSlashes = [](const std::string &_path,
++                            bool _stripLeading = false)
++  {
++    // Shortcut
++    if (_path.empty())
++      return _path;
++
++    std::string result = _path;
++
++    // Use the appropriate character for each platform.
++#ifndef _WIN32
++    char replacement = '/';
++#else
++    char replacement = '\\';
++#endif
++
++    // Sanitize the start of the path.
++    size_t index = 0;
++    size_t leadingIndex = _stripLeading ? 0 : 1;
++    for (; index < result.length() && result[index] == replacement; ++index)
++    {
++    }
++    if (index > leadingIndex)
++      result.erase(leadingIndex, index-leadingIndex);
++
++    // Sanitize the end of the path.
++    index = result.length()-1;
++    for (; index <  result.length() && result[index] == replacement; --index)
++    {
++    }
++    index += 1;
++    if (index < result.length()-1)
++        result.erase(index+1);
++    return result;
++  };
++
++  std::string path;
++#ifndef _WIN32
++  path = sanitizeSlashes(sanitizeSlashes(separator(_path1)) +
++      sanitizeSlashes(_path2, true));
++#else  // _WIN32
++  std::string path1 = sanitizeSlashes(checkWindowsPath(_path1));
++  std::string path2 = sanitizeSlashes(checkWindowsPath(_path2), true);
++  std::vector<CHAR> combined(path1.length() + path2.length() + 2);
++  if (::PathCombineA(combined.data(), path1.c_str(), path2.c_str()) != NULL)
++  {
++    path = sanitizeSlashes(checkWindowsPath(std::string(combined.data())));
++  }
++  else
++  {
++    path = sanitizeSlashes(checkWindowsPath(separator(path1) + path2));
++  }
++#endif  // _WIN32
++  return path;
++}
++
++
+ std::string getEngineInstallDir()
+ {
+-  return gz::common::joinPaths(getInstallPrefix(), GZ_PHYSICS_ENGINE_RELATIVE_INSTALL_DIR);
++  return gz::physics::joinPaths(
++      getInstallPrefix(), GZ_PHYSICS_ENGINE_RELATIVE_INSTALL_DIR);
+ }
+ 
+ }
+

--- a/recipe/bld_cxx.bat
+++ b/recipe/bld_cxx.bat
@@ -9,6 +9,7 @@ cmake ^
     -DBUILD_TESTING=ON ^
     -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON ^
     -DCMAKE_CXX_FLAGS="/permissive- /D_USE_MATH_DEFINES" ^
+    -DGZ_ENABLE_RELOCATABLE_INSTALL:BOOL=ON ^
     %SRC_DIR%
 if errorlevel 1 exit 1
 

--- a/recipe/build_cxx.sh
+++ b/recipe/build_cxx.sh
@@ -11,7 +11,7 @@ cd build
 cmake ${CMAKE_ARGS} .. \
       -G "Ninja" \
       -DCMAKE_BUILD_TYPE=Release \
-      -DCMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_SKIP=True ^
+      -DCMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_SKIP=True \
       -DGZ_ENABLE_RELOCATABLE_INSTALL:BOOL=ON
 
 cmake --build . --config Release ${NUM_PARALLEL}

--- a/recipe/build_cxx.sh
+++ b/recipe/build_cxx.sh
@@ -11,7 +11,8 @@ cd build
 cmake ${CMAKE_ARGS} .. \
       -G "Ninja" \
       -DCMAKE_BUILD_TYPE=Release \
-      -DCMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_SKIP=True
+      -DCMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_SKIP=True ^
+      -DGZ_ENABLE_RELOCATABLE_INSTALL:BOOL=ON
 
 cmake --build . --config Release ${NUM_PARALLEL}
 cmake --build . --config Release --target install ${NUM_PARALLEL}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,9 +18,10 @@ source:
       - disable_fake_install.patch
       - disable_integration_tests.patch  # [win]
       - workaround_win_base_test.patch  # [win]
+      - 507.patch
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   - name: {{ cxx_name }}


### PR DESCRIPTION
As merging https://github.com/gazebosim/gz-physics/pull/507 upstream is taking some time, let's backport the patch here. While this indeed introduces some new ABI symbols, if the symbols ends being changed in the upstream release, we can always re-introduce them with a custom patch, if that turns out to be necessary.

Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
