### PR TITLE
Migrate from dartsim to dartsim-cpp

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ source:
       - workaround_win_base_test.patch  # [win]
 
 build:
-  number: 6
+  number: 7
 
 outputs:
   - name: {{ cxx_name }}
@@ -45,7 +45,7 @@ outputs:
         - libsdformat14
         - eigen
         - assimp
-        - dartsim
+        - dartsim-cpp
         - libode
         - bullet-cpp
 


### PR DESCRIPTION
Since https://github.com/conda-forge/dartsim-feedstock/pull/75 `dartsim` contains both C++ and Python libraries, in Gazebo we just need the C++ library. Furthermore, this rebuilds gazebo against a version of dartsim that is built against fmt 11.

Similar to https://github.com/conda-forge/gazebo-feedstock/pull/227 .

Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
